### PR TITLE
Use monad-control instead of MonadCatchIO, and transformers than mtl

### DIFF
--- a/retry.cabal
+++ b/retry.cabal
@@ -14,7 +14,7 @@ description:
         case we should hang back for a bit and retry the query instead
         of simply raising an exception.
 
-version:             0.2.0.0
+version:             0.3.0.0
 synopsis:            Retry combinators for monadic actions that may fail
 license:             BSD3
 license-file:        LICENSE
@@ -29,8 +29,9 @@ library
   exposed-modules:     Control.Retry
   build-depends:       
     base ==4.*, 
-    MonadCatchIO-transformers >= 0.3,
-    mtl >= 0.2,
+    monad-control,
+    lifted-base,
+    transformers,
     data-default
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
MonadCatchIO is irredeemably broken, which monad-control was created to remedy.  Also, mtl is a superset of the behavior of transformers, and none of mtl's actual behavior is being used in this module.

Pinging @snoyberg, who suggested the change
