### PR TITLE
Use data-default-class instead of data-default to remove unnecessary dependencies

### DIFF
--- a/retry.cabal
+++ b/retry.cabal
@@ -32,7 +32,7 @@ library
     base            ==4.*, 
     exceptions      >= 0.5 && < 0.6,
     transformers,
-    data-default
+    data-default-class
   hs-source-dirs:      src
   default-language:    Haskell2010
 

--- a/src/Control/Retry.hs
+++ b/src/Control/Retry.hs
@@ -51,7 +51,7 @@ module Control.Retry
 import           Control.Concurrent
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class
-import           Data.Default
+import           Data.Default.Class
 import           Prelude                hiding (catch)
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
As of v0.5.2, `data-default` has been split into several packages. We'd need only `data-default-class` here.
