### PR TITLE
retry.cabal: allow exceptions-0.6 and hspec-1.10 in tests

### DIFF
--- a/retry.cabal
+++ b/retry.cabal
@@ -44,13 +44,13 @@ test-suite test
     ghc-options:    -threaded
     build-depends:       
         base              ==4.*  
-      , exceptions        >= 0.5   && < 0.6
+      , exceptions        >= 0.5   && < 0.7
       , transformers
       , data-default-class
       , time
       , QuickCheck         >= 2.7 && < 2.8
       , HUnit              >= 1.2.5.2 && < 1.3
-      , hspec              >= 1.9 && < 1.10
+      , hspec              >= 1.9 && < 1.11
     default-language: Haskell2010
 
 


### PR DESCRIPTION
Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
