### PR TITLE
recovering shouldn't change masking state in a recovered action

### DIFF
--- a/src/Control/Retry.hs
+++ b/src/Control/Retry.hs
@@ -238,9 +238,9 @@ recoverAll set f = recovering set [h] f
 -- retrying the action a number of times.
 recovering
 #if MIN_VERSION_exceptions(0, 6, 0)
-           :: forall m a. (MonadIO m, MonadMask m)
+           :: (MonadIO m, MonadMask m)
 #else
-           :: forall m a. (MonadIO m, MonadCatch m)
+           :: (MonadIO m, MonadCatch m)
 #endif
            => RetryPolicy
            -- ^ Just use 'def' faor default settings

--- a/src/Control/Retry.hs
+++ b/src/Control/Retry.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns          #-}
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes            #-}
@@ -218,7 +219,12 @@ retrying (RetryPolicy policy) chk f = go 0
 -- Running action
 -- Running action
 -- *** Exception: this is an error
-recoverAll :: (MonadIO m, MonadCatch m)
+recoverAll
+#if MIN_VERSION_exceptions(0, 6, 0)
+         :: (MonadIO m, MonadMask m)
+#else
+         :: (MonadIO m, MonadCatch m)
+#endif
          => RetryPolicy
          -> m a
          -> m a
@@ -230,7 +236,12 @@ recoverAll set f = recovering set [h] f
 -------------------------------------------------------------------------------
 -- | Run an action and recover from a raised exception by potentially
 -- retrying the action a number of times.
-recovering :: forall m a. (MonadIO m, MonadCatch m)
+recovering
+#if MIN_VERSION_exceptions(0, 6, 0)
+           :: forall m a. (MonadIO m, MonadMask m)
+#else
+           :: forall m a. (MonadIO m, MonadCatch m)
+#endif
            => RetryPolicy
            -- ^ Just use 'def' faor default settings
            -> [(Int -> Handler m Bool)]

--- a/test/RetrySpec.hs
+++ b/test/RetrySpec.hs
@@ -69,7 +69,7 @@ spec = parallel $ describe "retry" $ do
     it "associativity" $
       prop3 (\x y z -> x <> (y <> z)) (\x y z -> (x <> y) <> z)
 
-  it "shouldn't change masking state in a recovered action" $ TestCase $ do
+  it "shouldn't change masking state in a recovered action" $ do
     maskingState <- getMaskingState
     shouldThrow
       (recovering def testHandlers $ do
@@ -78,7 +78,7 @@ spec = parallel $ describe "retry" $ do
         fail "Retrying...")
       anyIOException
 
-  it "should mask asynchronous exceptions in exception handlers" $ TestCase $ do
+  it "should mask asynchronous exceptions in exception handlers" $ do
     let checkMaskingStateHandlers =
           [ const $ Handler $ \(_ :: SomeException) -> do
               maskingState <- getMaskingState


### PR DESCRIPTION
This is a bug report rather than a merge request. I've attached a failing test case to demonstrate the issue.

The problem is that when recovering, the masking state of the retrying action is set to `MaskedInterruptible` even though the original action has been run in `Unmasked`. It would be nice if the action retried in `Unmasked` state.

EDIT: The failing test output: https://travis-ci.org/Soostone/retry/builds/32917884#L137-L141