### PR TITLE
RetryPolicy not a monoid?

### DIFF
--- a/test/RetrySpec.hs
+++ b/test/RetrySpec.hs
@@ -2,6 +2,7 @@
 
 module RetrySpec where
 
+import           Data.Monoid
 import           Control.Applicative
 import           Control.Monad.Catch
 import           Control.Retry
@@ -12,12 +13,12 @@ import           Test.Hspec
 import           Test.Hspec.QuickCheck
 import           Test.QuickCheck
 import           Test.QuickCheck.Monadic as QCM
+import           Test.QuickCheck.Function (apply)
 
 isLeftAnd :: (a -> Bool) -> Either a b -> Bool
 isLeftAnd f ei = case ei of
   Left v -> f v
   _      -> False
-
 
 {-# ANN spec ("HLint: ignore Redundant do"::String) #-}
 spec :: Spec
@@ -36,4 +37,22 @@ spec = parallel $ describe "retry" $ do
     let ms' = (fromInteger . toInteger $ (timeout * retries)) / 1000000.0
     QCM.assert (diffUTCTime endTime startTime >= ms')
 
+  describe "Policy is a monoid" $ do
+    let toPolicy = RetryPolicy . apply
+    let prop left right  =
+          property $ \a x -> 
+                      let applyPolicy f = getRetryPolicy (f $ toPolicy a) x in
+                      applyPolicy left == applyPolicy right
+    let prop3 left right  =
+          property $ \a b c x -> 
+                      let applyPolicy f = getRetryPolicy (f (toPolicy a) (toPolicy b) (toPolicy c)) x in
+                      applyPolicy left == applyPolicy right
 
+    it "left identity" $
+      prop (\p -> mempty <> p) id
+
+    it "right identity" $
+      prop (\p -> p <> mempty) id
+
+    it "associativity" $
+      prop3 (\x y z -> x <> (y <> z)) (\x y z -> (x <> y) <> z)


### PR DESCRIPTION
`RetryPolicy` seems to fail the identity laws for a monoid. This also seems to be indicated in the docs for `RetryPolicy`:

> -- 1. If either policy returns 'Nothing', the combined policy returns
> -- 'Nothing'. This can be used to @inhibit@ after a number of retries,
> -- for example.

I'm a haskell newbie so I might be misreading something or not testing things right. I tried to use [`checkers`](https://hackage.haskell.org/package/checkers) but the dependencies don't match.
Any kind of confirmation (either way) would be great.

Thanks
