### PR TITLE
Pass current retry number to action.

### DIFF
--- a/test/QuadraticDelayRetrySpec.hs
+++ b/test/QuadraticDelayRetrySpec.hs
@@ -29,7 +29,7 @@ spec = parallel $ describe "quadratic delay" $ do
     retries <- pick . choose $ (0,8)
     res <- run . try $ recovering (exponentialBackoff timeout <> limitRetries retries)
                               [const $ Handler (\(_::SomeException) -> return True)]
-                              (throwM (userError "booo"))
+                              (const $ throwM (userError "booo"))
     endTime <- run getCurrentTime
     QCM.assert (isLeftAnd isUserError res)
     let tmo = if retries > 0 then timeout * 2 ^ (retries - 1) else 0

--- a/test/RetrySpec.hs
+++ b/test/RetrySpec.hs
@@ -34,7 +34,7 @@ spec = parallel $ describe "retry" $ do
     retries <- getSmall . getPositive <$> pick arbitrary
     res <- run . try $ recovering (constantDelay timeout <> limitRetries retries)
                               [const $ Handler (\(_::SomeException) -> return True)]
-                              (throwM (userError "booo"))
+                              (const $ throwM (userError "booo"))
     endTime <- run getCurrentTime
     QCM.assert (isLeftAnd isUserError res)
     let ms' = (fromInteger . toInteger $ (timeout * retries)) / 1000000.0


### PR DESCRIPTION
Instead of retrying plain monadic actions `m a` pass instead the current
retry number to this action. This allows it to react differently
depending on the number of iterations. Actions can resort to `const` if
they prefer to be ignorant of this additional information.