### PR TITLE
Add support for retrying `MonadError` actions.

### DIFF
--- a/retry.cabal
+++ b/retry.cabal
@@ -32,6 +32,7 @@ library
       base                 ==4.*
     , data-default-class
     , exceptions           >= 0.5 && < 0.9
+    , mtl                  >= 2.1
     , random               >= 1 && < 1.2
     , transformers         < 0.5
   hs-source-dirs:      src


### PR DESCRIPTION
For lack of a better name I provisionally chose `retryE`.