### PR TITLE
should retry even handle async exceptions

### DIFF
--- a/retry.cabal
+++ b/retry.cabal
@@ -1,6 +1,6 @@
 name:                retry
 
-description: 
+description:
 
         This package exposes combinators that can wrap arbitrary
         monadic actions. They run the action and potentially retry
@@ -28,7 +28,7 @@ Homepage:            http://github.com/Soostone/retry
 
 library
   exposed-modules:     Control.Retry
-  build-depends:       
+  build-depends:
       base                 ==4.*
     , data-default-class
     , exceptions           >= 0.5 && < 0.9
@@ -43,8 +43,8 @@ test-suite test
     main-is:        main.hs
     hs-source-dirs: test,src
     ghc-options:    -threaded
-    build-depends:       
-        base              ==4.*  
+    build-depends:
+        base              ==4.*
       , exceptions
       , transformers
       , data-default-class
@@ -53,9 +53,5 @@ test-suite test
       , QuickCheck         >= 2.7 && < 2.8
       , HUnit              >= 1.2.5.2 && < 1.3
       , hspec              >= 1.9
+      , stm
     default-language: Haskell2010
-
-
-
-
- 

--- a/test/RetrySpec.hs
+++ b/test/RetrySpec.hs
@@ -8,7 +8,7 @@ import           Control.Applicative
 import           Control.Concurrent
 import           Control.Concurrent.MVar
 import           Control.Concurrent.STM
-import           Control.Exception        (ErrorCall (..), MaskingState (..),
+import           Control.Exception        (AsyncException (..), MaskingState (..),
                                            getMaskingState, throwTo)
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class
@@ -88,7 +88,7 @@ spec = parallel $ describe "retry" $ do
         recoverAll (limitRetries 2) work `finally` putMVar done ()
 
       atomically (check . (== 1) =<< readTVar counter)
-      throwTo tid (ErrorCall "boom")
+      throwTo tid UserInterrupt
 
       takeMVar done
 


### PR DESCRIPTION
Don't actually merge this yet. This is for discussion.

@ozataman and I were discussing this and we thought it would be appropriate to loop in users and see what they thought. Tagging in @maoe @LukeHoersten @bergmark @twittner @tiago-loureiro

The concern is that currently retry catches all exceptions, including async ones and coerces them to `SomeException`. It then runs through handlers and if none catch it, rethrow using `throwM` as *synchronous* exceptions. The prevailing wisdom seems to be that async exceptions are not to be caught, only paused for critical sections, as they typically represent other parts of the system intending to bring down the targeted thread.

The worst case scenario here is if you are lazy and just set up a `SomeException` handler that returns `True` (or if you use `recoverAll`) and use retry with say a max retry count of 2 and something else in your system tries to interrupt and shut down your thread, `retry` will eat the exception, re-runs the action and under most circumstances, the async exception is not re-sent again, thus hanging the program indefinitely. See the test case below for an example. 

So, first question: is the way `retry` behaves now unreasonable? One needs to be very careful using `recovering` to avoid async exceptions, providing `Handler`s that select for `SomeAsyncException` and/or `AsyncException` explicitly, and `recoverAll` is entirely immune to async exceptions. 

If retry's behavior does need to be changed, we were thinking of using `tryAny` from `enclosed-exceptions` in `retry`'s `recovering` function. This would catch *only* exceptions coming from the supplied action. External exceptions targeted at the thread that `retry` uses would not be masked and would crash the thread. Is this a reasonable approach?