### PR TITLE
Idea for improving forward compatibility

### DIFF
--- a/test/RetrySpec.hs
+++ b/test/RetrySpec.hs
@@ -146,7 +146,7 @@ spec = parallel $ describe "retry" $ do
     let toPolicy = retryPolicy . apply
     let prop left right  =
           property $ \a x ->
-            let applyPolicy f = getRetryPolicyM (f $ toPolicy a) x
+            let applyPolicy f = getRetryPolicy (f $ toPolicy a) x
                 validRes = maybe True (>= 0)
             in  monadicIO $ do
                 l <- liftIO $ applyPolicy left
@@ -157,7 +157,7 @@ spec = parallel $ describe "retry" $ do
 
     let prop3 left right  =
           property $ \a b c x ->
-            let applyPolicy f = liftIO $ getRetryPolicyM (f (toPolicy a) (toPolicy b) (toPolicy c)) x
+            let applyPolicy f = liftIO $ getRetryPolicy (f (toPolicy a) (toPolicy b) (toPolicy c)) x
             in monadicIO $ do
                   res <- (==) <$> applyPolicy left <*> applyPolicy right
                   assert res


### PR DESCRIPTION
I've run into some dependencies that use the RetryPolicy constructor
from 0.6 as well as getRetryPolicy. This has been renamed in 0.7, but
because RetryPolicy is a type alias, we could retain the same
constructor name and newtype accessor to make upgrades easier. I have
unfortunately found that because of the polymorphic m on RetryPolicyM
that the user will have to add RankNTypes if they don't have it already,
but no actual code will need to change.