### PR TITLE
Require GHC >= 7.6 since the library uses GHC.Generics

### DIFF
--- a/retry.cabal
+++ b/retry.cabal
@@ -32,7 +32,7 @@ extra-source-files:
 library
   exposed-modules:     Control.Retry
   build-depends:
-      base                 ==4.*
+      base                 >= 4.6 && < 5
     , data-default-class
     , exceptions           >= 0.5 && < 0.9
     , random               >= 1 && < 1.2


### PR DESCRIPTION
Alternate solution is to (conditionally) add ghc-prim as a dependency for older GHCs but I haven't tested whether this is the only thing needed for the library to compile.

Revision: http://hackage.haskell.org/package/retry-0.7/revisions/
Build matrix: http://matrix.hackage.haskell.org/package/retry
