### PR TITLE
Use unbounded Integers throughout retry

### DIFF
--- a/retry.cabal
+++ b/retry.cabal
@@ -37,6 +37,7 @@ library
     , exceptions           >= 0.5 && < 0.9
     , random               >= 1 && < 1.2
     , transformers         < 0.6
+    , unbounded-delays     >= 0.1.0.9 && < 0.2
   hs-source-dirs:      src
   default-language:    Haskell2010
 
@@ -57,4 +58,6 @@ test-suite test
       , HUnit              >= 1.2.5.2 && < 1.4
       , hspec              >= 1.9
       , stm
+      , mtl
+      , unbounded-delays
     default-language: Haskell2010


### PR DESCRIPTION
This addresses #36 and makes retry generally suitable for calculations
made on larger delays.

Even though `maxBound :: Int` microseconds is many years, the math we're
doing on policies pretty easily overruns the bounds such that I got a
policy to roll over after < 30s of delay. This becomes a non-issue when
we use integers, and the `unbounded-delays` package provides us with an
Integer based delay primitive. `unbounded-delays` has no dependencies
beyond base and works by converting an Integer delay that exceeds
maxBound into successive calls to `threadDelay` with numbers that fit
into Int.

I suspect many users would not have to change anything for this to work
in places where Int was being determined by type inference, but this
should constitute a breaking version change.