### PR TITLE
Increase upper bound of ghc-prim

### DIFF
--- a/retry.cabal
+++ b/retry.cabal
@@ -35,7 +35,7 @@ library
       base                 >= 4.6 && < 5
     , data-default-class
     , exceptions           >= 0.5 && < 0.9
-    , ghc-prim             < 0.5
+    , ghc-prim             < 0.6
     , random               >= 1 && < 1.2
     , transformers         < 0.6
   hs-source-dirs:      src


### PR DESCRIPTION
Since GHC8 comes with ghc-prim 0.5.

This compiles with GHC 8.0.1-rc4.