### PR TITLE
Stackage LTS 9 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,14 @@ addons:
 # The different configurations we want to test. You could also do things like
 # change flags or use --stack-yaml to point to a different file.
 env:
-# - ARGS="--resolver=lts-2"
-# - ARGS="--resolver=lts-3"
-# - ARGS="--resolver=lts-4"
-# - ARGS="--resolver=lts-5"
-# - ARGS="--resolver=lts-6"
-# - ARGS="--resolver=lts-7"
-# - ARGS="--resolver=lts-8"
-# - ARGS="--resolver=lts-9"
+- ARGS="--resolver=lts-2"
+- ARGS="--resolver=lts-3"
+- ARGS="--resolver=lts-4"
+- ARGS="--resolver=lts-5"
+- ARGS="--resolver=lts-6"
+- ARGS="--resolver=lts-7"
+- ARGS="--resolver=lts-8"
+- ARGS="--resolver=lts-9"
 - ARGS="--resolver=nightly"
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,14 @@ addons:
 # The different configurations we want to test. You could also do things like
 # change flags or use --stack-yaml to point to a different file.
 env:
-- ARGS="--resolver=lts-2"
-- ARGS="--resolver=lts-3"
-- ARGS="--resolver=lts-4"
-- ARGS="--resolver=lts-5"
-- ARGS="--resolver=lts-6"
-- ARGS="--resolver=lts-7"
-- ARGS="--resolver=lts-8"
-- ARGS="--resolver=lts-9"
+# - ARGS="--resolver=lts-2"
+# - ARGS="--resolver=lts-3"
+# - ARGS="--resolver=lts-4"
+# - ARGS="--resolver=lts-5"
+# - ARGS="--resolver=lts-6"
+# - ARGS="--resolver=lts-7"
+# - ARGS="--resolver=lts-8"
+# - ARGS="--resolver=lts-9"
 - ARGS="--resolver=nightly"
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ env:
 - ARGS="--resolver=lts-4"
 - ARGS="--resolver=lts-5"
 - ARGS="--resolver=lts-6"
+- ARGS="--resolver=lts-7"
+- ARGS="--resolver=lts-8"
+- ARGS="--resolver=lts-9"
 - ARGS="--resolver=nightly"
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -33,4 +33,5 @@ Contributors, please list yourself here.
 - John Wiegley
 - Michael Snoyman
 - Michael Xavier
+- Marco Zocca (@ocramz)
 

--- a/retry.cabal
+++ b/retry.cabal
@@ -54,8 +54,8 @@ test-suite test
       , data-default-class
       , random
       , time
-      , QuickCheck         >= 2.7 && < 2.10
-      , HUnit              >= 1.2.5.2 && < 1.6
+      , QuickCheck         >= 2.7 && <= 2.10
+      , HUnit              >= 1.2.5.2 && <= 1.6
       , hspec              >= 1.9
       , stm
       , ghc-prim

--- a/retry.cabal
+++ b/retry.cabal
@@ -54,8 +54,8 @@ test-suite test
       , data-default-class
       , random
       , time
-      , QuickCheck         >= 2.7 && <= 2.10
-      , HUnit              >= 1.2.5.2 && <= 1.6
+      , QuickCheck         >= 2.7 && < 2.11
+      , HUnit              >= 1.2.5.2 && < 1.7
       , hspec              >= 1.9
       , stm
       , ghc-prim

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-6.0
+resolver: lts-9.0
 packages:
 - '.'
 extra-deps: []


### PR DESCRIPTION
* added travis testing for all LTS versions up to and including 9
* relaxed cabal upper bounds that were preventing testing with LTS nightly-2017-10-23 (fixed #52 )