### PR TITLE
Support GHC 8.8

### DIFF
--- a/retry.cabal
+++ b/retry.cabal
@@ -39,7 +39,7 @@ library
       base                 >= 4.6 && < 5
     , exceptions           >= 0.5 && < 0.11
     , ghc-prim             < 0.6
-    , random               >= 1 && < 1.2
+    , random               >= 1 && < 1.4
     , transformers         < 0.7
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
Pardon an automatically-posted pull request; this is a part of [Operation Vanguard](https://github.com/haskell-vanguard/haskell-vanguard). Note that this does not guarantee that tests and benchmarks are buildable.