### PR TITLE
Bump GHC prim upper bound

### DIFF
--- a/retry.cabal
+++ b/retry.cabal
@@ -38,7 +38,7 @@ library
   build-depends:
       base                 >= 4.6 && < 5
     , exceptions           >= 0.5
-    , ghc-prim             < 0.6
+    , ghc-prim             < 0.7
     , random               >= 1
     , transformers
   hs-source-dirs:      src


### PR DESCRIPTION
In order to compile on `ghc-8.10.1`