### PR TITLE
Relax constraints to `Applicative`

### DIFF
--- a/src/Control/Retry.hs
+++ b/src/Control/Retry.hs
@@ -161,23 +161,18 @@ retryPolicyDefault = constantDelay 50000 <> limitRetries 5
 -- dependencies than the semigroups package, so we're using base's
 -- only if its available.
 # if MIN_VERSION_base(4, 9, 0)
-instance Monad m => Semigroup (RetryPolicyM m) where
-  (RetryPolicyM a) <> (RetryPolicyM b) = RetryPolicyM $ \ n -> runMaybeT $ do
-    a' <- MaybeT $ a n
-    b' <- MaybeT $ b n
-    return $! max a' b'
+instance Applicative m => Semigroup (RetryPolicyM m)
+  where
+  RetryPolicyM a <> RetryPolicyM b = RetryPolicyM $ liftA2 (liftA2 (liftA2 max)) a b
 
-
-instance Monad m => Monoid (RetryPolicyM m) where
-    mempty = retryPolicy $ const (Just 0)
-    mappend = (<>)
+instance Applicative m => Monoid (RetryPolicyM m)
+  where
+  mempty = RetryPolicyM $ pure $ pure $ pure 0
 # else
-instance Monad m => Monoid (RetryPolicyM m) where
-    mempty = retryPolicy $ const (Just 0)
-    (RetryPolicyM a) `mappend` (RetryPolicyM b) = RetryPolicyM $ \ n -> runMaybeT $ do
-      a' <- MaybeT $ a n
-      b' <- MaybeT $ b n
-      return $! max a' b'
+instance Applicative m => Monoid (RetryPolicyM m)
+  where
+  RetryPolicyM a <> RetryPolicyM b = RetryPolicyM $ liftA2 (liftA2 (liftA2 max)) a b
+  mempty = RetryPolicyM $ pure $ pure $ pure 0
 #endif
 
 

--- a/src/Control/Retry.hs
+++ b/src/Control/Retry.hs
@@ -90,7 +90,6 @@ import           Control.Monad
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Class
-import           Control.Monad.Trans.Maybe
 import           Control.Monad.Trans.State
 import           Data.List (foldl')
 import           Data.Maybe


### PR DESCRIPTION
Hello there. It doesn't seem like there's a reason for the `Semigroup`/`Monoid` instance to depend on `Monad`, given that it's essentially `Max Nat` lifted through a variety of applicatives. Does a reformulation that just depends on Applicative make sense to you?