### PR TITLE
Switch from RetryPolicy to RetryPolicyM

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+0.9.0.0
+* Replace several uses of RetryPolicy type alias with RetryPolicyM m for better
+  GHC 9 compat.
+
 0.8.1.2
 * Set lower bound on base to >= 4.8
 

--- a/retry.cabal
+++ b/retry.cabal
@@ -14,7 +14,7 @@ description:
         case we should hang back for a bit and retry the query instead
         of simply raising an exception.
 
-version:             0.8.1.2
+version:             0.9.0.0
 synopsis:            Retry combinators for monadic actions that may fail
 license:             BSD3
 license-file:        LICENSE

--- a/src/Control/Retry.hs
+++ b/src/Control/Retry.hs
@@ -153,7 +153,7 @@ newtype RetryPolicyM m = RetryPolicyM { getRetryPolicyM :: RetryStatus -> m (May
 type RetryPolicy = forall m . Monad m => RetryPolicyM m
 
 -- | Default retry policy
-retryPolicyDefault :: RetryPolicy
+retryPolicyDefault :: (Monad m) => RetryPolicyM m
 retryPolicyDefault = constantDelay 50000 <> limitRetries 5
 
 
@@ -303,7 +303,7 @@ applyAndDelay policy s = do
 -------------------------------------------------------------------------------
 -- | Helper for making simplified policies that don't use the monadic
 -- context.
-retryPolicy :: (RetryStatus -> Maybe Int) -> RetryPolicy
+retryPolicy :: (Monad m) => (RetryStatus -> Maybe Int) -> RetryPolicyM m
 retryPolicy f = RetryPolicyM $ \ s -> return (f s)
 
 
@@ -355,9 +355,10 @@ limitRetriesByCumulativeDelay cumulativeLimit p = RetryPolicyM $ \ stat ->
 -------------------------------------------------------------------------------
 -- | Implement a constant delay with unlimited retries.
 constantDelay
-    :: Int
+    :: (Monad m)
+    => Int
     -- ^ Base delay in microseconds
-    -> RetryPolicy
+    -> RetryPolicyM m
 constantDelay delay = retryPolicy (const (Just delay))
 
 
@@ -365,9 +366,10 @@ constantDelay delay = retryPolicy (const (Just delay))
 -- | Grow delay exponentially each iteration.  Each delay will
 -- increase by a factor of two.
 exponentialBackoff
-    :: Int
+    :: (Monad m)
+    => Int
     -- ^ Base delay in microseconds
-    -> RetryPolicy
+    -> RetryPolicyM m
 exponentialBackoff base = retryPolicy $ \ RetryStatus { rsIterNumber = n } ->
   Just $! base `boundedMult` boundedPow 2 n
 
@@ -381,7 +383,7 @@ exponentialBackoff base = retryPolicy $ \ RetryStatus { rsIterNumber = n } ->
 --
 -- sleep = temp \/ 2 + random_between(0, temp \/ 2)
 fullJitterBackoff
-    :: MonadIO m
+    :: (MonadIO m)
     => Int
     -- ^ Base delay in microseconds
     -> RetryPolicyM m
@@ -394,9 +396,10 @@ fullJitterBackoff base = RetryPolicyM $ \ RetryStatus { rsIterNumber = n } -> do
 -------------------------------------------------------------------------------
 -- | Implement Fibonacci backoff.
 fibonacciBackoff
-    :: Int
+    :: (Monad m)
+    => Int
     -- ^ Base delay in microseconds
-    -> RetryPolicy
+    -> RetryPolicyM m
 fibonacciBackoff base = retryPolicy $ \RetryStatus { rsIterNumber = n } ->
   Just $ fib (n + 1) (0, base)
     where

--- a/test/Tests/Control/Retry.hs
+++ b/test/Tests/Control/Retry.hs
@@ -400,7 +400,7 @@ genRetryStatus = do
 -------------------------------------------------------------------------------
 -- | Generate an arbitrary 'RetryPolicy' without any limits applied.
 genPolicyNoLimit
-    :: (MonadGen mg, MonadIO mr)
+    :: forall mg mr. (MonadGen mg, MonadIO mr)
     => Range Int
     -> mg (RetryPolicyM mr)
 genPolicyNoLimit durationRange =


### PR DESCRIPTION
It seems like the RetryPolicy type alias can sometimes cause problems
with type paramter scope in GHC 9. It doesn't really buy us much so we
might as well use the most flexible option.

This is for #71