### PR TITLE
Add resumable retrying/recovering variants

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+0.9.1.0
+* Add resumable retry/recover variants:
+  * `resumeRetrying`
+  * `resumeRetryingDynamic`
+  * `resumeRecovering`
+  * `resumeRecoveringDynamic`
+  * `resumeRecoverAll`
+
 0.9.0.0
 * Replace several uses of RetryPolicy type alias with RetryPolicyM m for better
   GHC 9 compat.


### PR DESCRIPTION
This PR adds resumable variants of the relevant retrying and recovering operations and addresses #74. I opted for a `resume-` prefix as a starting point, and am happy to change these names around to the maintainers' preferences.