### PR TITLE
explicitly import forM_ in test; fix tests on GHC 9.6

### DIFF
--- a/test/Tests/Control/Retry.hs
+++ b/test/Tests/Control/Retry.hs
@@ -20,6 +20,7 @@ import           Control.Applicative
 import           Control.Concurrent
 import           Control.Concurrent.STM      as STM
 import qualified Control.Exception           as EX
+import           Control.Monad               ( forM_ )
 import           Control.Monad.Catch
 import           Control.Monad.Except
 import           Control.Monad.Identity


### PR DESCRIPTION
Tests are broken on GHC 9.6 due to an unscoped `forM_` usage. It used to be exported by `Data.Foldable`, and does appear to be present from there on GHC 9.2.7. I can't see where `Data.Foldable` is imported -- I assume it's re-exported by one of the imports, but I can't tell which.